### PR TITLE
case classes without parameters are refactored as case objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.cache-main
+.cache-tests
+.classpath
+.project
+.settings/
 
 # IntelliJ
 .idea
+/bin/

--- a/src/main/scala/juju/infrastructure/EventBus.scala
+++ b/src/main/scala/juju/infrastructure/EventBus.scala
@@ -17,14 +17,14 @@ object EventBus {
   def props() = Props(classOf[EventBus])
 }
 
-case class HandlerNotDefinedException() extends Exception
+case object HandlerNotDefinedException extends Exception
 case class MessageNotSupported(text: String) extends Exception(text)
 case class UpdateHandlers(handlers : Map[Class[_ <: Command], ActorRef]) extends InfrastructureMessage
 
 case class RegisterHandlers[A <: AggregateRoot[_]](implicit val officeFactory: OfficeFactory[A], val resolver: AggregateHandlersResolution[A]) extends InfrastructureMessage
 case class HandlersRegistered(handlers : Iterable[Class[_ <: Command]]) extends InfrastructureMessage
 case class RegisterSaga[S <: Saga](implicit val routerFactory : SagaRouterFactory[S], val resolver: SagaHandlersResolution[S]) extends InfrastructureMessage
-case class GetSubscribedDomainEvents() extends InfrastructureMessage
+case object GetSubscribedDomainEvents extends InfrastructureMessage
 case class DomainEventsSubscribed(events: Iterable[Class[_ <: DomainEvent]]) extends InfrastructureMessage
 
 class EventBus extends Actor with ActorLogging with Stash {
@@ -44,7 +44,7 @@ class EventBus extends Actor with ActorLogging with Stash {
 
       handlers.get(commandType) match {
         case Some(office) => office ! command
-        case None => sender ! akka.actor.Status.Failure(HandlerNotDefinedException())
+        case None => sender ! akka.actor.Status.Failure(HandlerNotDefinedException)
       }
 
     case activate : Activate =>
@@ -111,7 +111,7 @@ class EventBus extends Actor with ActorLogging with Stash {
 
       routerRef.ask(UpdateHandlers(handlers)).onSuccess {
         case results =>
-          routerRef.tell(GetSubscribedDomainEvents(), s)
+          routerRef.tell(GetSubscribedDomainEvents, s)
           log.debug(s"saga $routerRef registered")
       }
 

--- a/src/main/scala/juju/infrastructure/local/LocalSagaRouter.scala
+++ b/src/main/scala/juju/infrastructure/local/LocalSagaRouter.scala
@@ -58,7 +58,7 @@ class LocalSagaRouter[S <: Saga](implicit ct: ClassTag[S], handlersResolution: S
   }
 
   override def receive: Receive = {
-    case e : GetSubscribedDomainEvents => sender ! DomainEventsSubscribed(subscribedEvents)
+    case e@GetSubscribedDomainEvents => sender ! DomainEventsSubscribed(subscribedEvents)
     case e : Activate =>
       log.debug(s"received activate $e message")
       getOrCreateSaga(e.correlationId)

--- a/src/main/scala/juju/messages/Boot.scala
+++ b/src/main/scala/juju/messages/Boot.scala
@@ -1,3 +1,3 @@
 package juju.messages
 
-case class Boot() extends InfrastructureMessage
+case object Boot extends InfrastructureMessage

--- a/src/test/scala/juju/testkit/infrastructure/EventBusSpec.scala
+++ b/src/test/scala/juju/testkit/infrastructure/EventBusSpec.scala
@@ -28,7 +28,7 @@ abstract class EventBusSpec(prefix:String) extends DomainSpec(s"${prefix}EventBu
   it should "not able to send a message with no registered handler" in {
     withEventBus { busRef =>
       busRef ! CreatePriority("fake")
-      expectMsg(akka.actor.Status.Failure(HandlerNotDefinedException()))
+      expectMsg(akka.actor.Status.Failure(HandlerNotDefinedException))
     }
   }
 


### PR DESCRIPTION
All the juju case classes without class params have been transformed to case object to make them compliant with Scala 2.10 best practices.