### PR TITLE
Configurations over conventions

### DIFF
--- a/src/main/java/juju/domain/resolvers/ActivatedBy.java
+++ b/src/main/java/juju/domain/resolvers/ActivatedBy.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ActivatedBy {
-    public Class[] messages();
+    public Class message();
 }

--- a/src/main/java/juju/domain/resolvers/ActivatedBy.java
+++ b/src/main/java/juju/domain/resolvers/ActivatedBy.java
@@ -1,0 +1,12 @@
+package juju.domain.resolvers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ActivatedBy {
+    public Class[] messages();
+}

--- a/src/main/java/juju/domain/resolvers/AggregateIdField.java
+++ b/src/main/java/juju/domain/resolvers/AggregateIdField.java
@@ -1,0 +1,12 @@
+package juju.domain.resolvers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AggregateIdField {
+    public String fieldname() default "";
+}

--- a/src/main/java/juju/domain/resolvers/AggregateIdField.java
+++ b/src/main/java/juju/domain/resolvers/AggregateIdField.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target(ElementType.METHOD)
 public @interface AggregateIdField {
     public String fieldname() default "";
 }

--- a/src/main/java/juju/domain/resolvers/CorrelationIdField.java
+++ b/src/main/java/juju/domain/resolvers/CorrelationIdField.java
@@ -1,0 +1,12 @@
+package juju.domain.resolvers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CorrelationIdField {
+    public String fieldname() default "";
+}

--- a/src/main/scala/juju/domain/AggregateRoot.scala
+++ b/src/main/scala/juju/domain/AggregateRoot.scala
@@ -15,6 +15,12 @@ trait AggregateState {
   def apply: StateMachine
 }
 
+case class EmptyState() extends AggregateState {
+  override def apply = {
+    case _ => EmptyState()
+  }
+}
+
 object AggregateRoot {
   trait AggregateIdResolution[A <: AggregateRoot[_]] {
     def resolve(command: Command) : String

--- a/src/main/scala/juju/domain/AggregateRoot.scala
+++ b/src/main/scala/juju/domain/AggregateRoot.scala
@@ -31,10 +31,6 @@ object AggregateRoot {
   }
 }
 
-/*trait Handle[C <: Command] {
-  def handle(command: C) : Unit
-}*/
-
 abstract class AggregateRoot[S <: AggregateState]
   extends PersistentActor with ActorLogging {
 
@@ -43,7 +39,7 @@ abstract class AggregateRoot[S <: AggregateState]
   log.debug(s"created AggregateRoot ${this.getClass.getCanonicalName} with id $id")
   private var stateOpt: Option[S] = None
 
-  def isStateInitialized = !stateOpt.isEmpty
+  def isStateInitialized = stateOpt.isDefined
   protected def state = if (isStateInitialized) stateOpt.get else throw new AggregateRootNotInitializedException
 
   type AggregateStateFactory = PartialFunction[DomainEvent, S]
@@ -52,7 +48,6 @@ abstract class AggregateRoot[S <: AggregateState]
   private lazy val handlers = this.getClass.getDeclaredMethods
     .filter(_.getParameterTypes.length == 1)
     .filter( _.getName == "handle")
-    //.filter( _.getName == classOf[Handle[_ <: Command]].getMethods.head.getName)
     .filter(_.getParameterTypes.head != classOf[Command])
 
   def handle : Receive = {

--- a/src/main/scala/juju/domain/AggregateRoot.scala
+++ b/src/main/scala/juju/domain/AggregateRoot.scala
@@ -31,9 +31,9 @@ object AggregateRoot {
   }
 }
 
-trait Handle[A <: Command] {
-  def handle(command: A) : Unit
-}
+/*trait Handle[C <: Command] {
+  def handle(command: C) : Unit
+}*/
 
 abstract class AggregateRoot[S <: AggregateState]
   extends PersistentActor with ActorLogging {
@@ -51,7 +51,8 @@ abstract class AggregateRoot[S <: AggregateState]
 
   private lazy val handlers = this.getClass.getDeclaredMethods
     .filter(_.getParameterTypes.length == 1)
-    .filter( _.getName == classOf[Handle[_ <: Command]].getMethods.head.getName)
+    .filter( _.getName == "handle")
+    //.filter( _.getName == classOf[Handle[_ <: Command]].getMethods.head.getName)
     .filter(_.getParameterTypes.head != classOf[Command])
 
   def handle : Receive = {

--- a/src/main/scala/juju/domain/resolvers/ByConventions.scala
+++ b/src/main/scala/juju/domain/resolvers/ByConventions.scala
@@ -1,0 +1,17 @@
+package juju.domain.resolvers
+
+import juju.domain.{Handle, AggregateRoot}
+import juju.domain.AggregateRoot.AggregateHandlersResolution
+import juju.messages.Command
+
+import scala.reflect.ClassTag
+
+object ByConventions {
+  implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag]() = new AggregateHandlersResolution[A] {
+    override def resolve(): Seq[Class[_ <: Command]] = implicitly[ClassTag[A]].runtimeClass.getDeclaredMethods
+      .filter(_.getParameterTypes.length == 1)
+      .filter(_.getName == classOf[Handle[_ <: Command]].getMethods.head.getName)
+      .map(_.getParameterTypes.head.asInstanceOf[Class[_ <: Command]])
+      .filter(_ != classOf[Command])
+  }
+}

--- a/src/main/scala/juju/domain/resolvers/ByConventions.scala
+++ b/src/main/scala/juju/domain/resolvers/ByConventions.scala
@@ -2,10 +2,10 @@ package juju.domain.resolvers
 
 import java.lang.reflect.Method
 
-import akka.actor.Props
+import akka.actor.{ActorRef, Props}
 import juju.domain.AggregateRoot.{AggregateHandlersResolution, AggregateIdResolution}
-import juju.domain.Saga.SagaHandlersResolution
-import juju.domain.{AggregateRoot, AggregateRootFactory, Saga}
+import juju.domain.Saga.{SagaCorrelationIdResolution, SagaHandlersResolution}
+import juju.domain.{AggregateRoot, AggregateRootFactory, Saga, SagaFactory}
 import juju.messages.{Activate, Command, DomainEvent, WakeUp}
 
 import scala.reflect.ClassTag
@@ -23,11 +23,11 @@ object ByConventions {
       .filter(_ != classOf[Command])
   }
 
-  implicit def factory[A <: AggregateRoot[_] : ClassTag]() = new AggregateRootFactory[A] {
+  implicit def aggregateFactory[A <: AggregateRoot[_] : ClassTag]() = new AggregateRootFactory[A] {
     override def props: Props = Props(implicitly[ClassTag[A]].runtimeClass)
   }
 
-  implicit def idResolution[A <: AggregateRoot[_] : ClassTag]() = new AggregateIdResolution[A] {
+  implicit def aggregateIdResolution[A <: AggregateRoot[_] : ClassTag]() = new AggregateIdResolution[A] {
     override def resolve(command: Command): String = {
       val aggregateTypename = implicitly[ClassTag[A]].runtimeClass.getSimpleName
 
@@ -61,9 +61,11 @@ object ByConventions {
     override def resolve(): Seq[Class[_ <: DomainEvent]] = handleMethods[S]("apply")
       .map(_.getParameterTypes.head.asInstanceOf[Class[_ <: DomainEvent]])
       .filter(_ != classOf[DomainEvent])
+ 
     override def wakeUpBy(): Seq[Class[_ <: WakeUp]] = handleMethods[S]("wakeup")
       .map(_.getParameterTypes.head.asInstanceOf[Class[_ <: WakeUp]])
       .filter(_ != classOf[WakeUp])
+   
     override def activateBy() : Option[Class[_ <: Activate]] = {
       val sagaClass = implicitly[ClassTag[S]].runtimeClass
       val activate = sagaClass.getDeclaredAnnotations find { _.annotationType() == classOf[ActivatedBy] }
@@ -76,6 +78,43 @@ object ByConventions {
         None.asInstanceOf[Option[Class[_ <: Activate]]]
       }
       res
+    }
+  }
+
+  implicit def sagaFactory[S <: Saga : ClassTag]() = new SagaFactory[S] {
+    override def props(correlationId: String, commandRouter: ActorRef): Props = Props(implicitly[ClassTag[S]].runtimeClass, correlationId, commandRouter)
+  }
+
+  implicit def correlationIdResolution[S <: Saga : ClassTag]() = new SagaCorrelationIdResolution[S] {
+    /**
+     * resolve returns an error if the event haven't to be handled (signal a wrong routing logic) otherwise returns None if a handled event has specific condition, otherwise it returns the correlationid
+     */
+    override def resolve(event: DomainEvent): Option[String] = {
+      val sagaTypename = implicitly[ClassTag[S]].runtimeClass.getSimpleName
+
+      val handlers = handleMethods("apply")
+      val eventClass = event.getClass
+      val handle = handlers.filter(_.getGenericParameterTypes.head == eventClass).head
+      val annotation = handle.getDeclaredAnnotation[CorrelationIdField](classOf[CorrelationIdField])
+
+      val fieldname = Option(annotation) match {
+        case None =>
+          val methodWithNameCorrelationId = eventClass.getMethods.find(_.getName == "CorrelationId")
+          val methodWithNameId = eventClass.getMethods.find(_.getName == "Id")
+          (methodWithNameCorrelationId getOrElse {
+            methodWithNameId getOrElse {
+              throw new IllegalArgumentException(s"Not provided CorrelationIdField annotation for event '${eventClass.getSimpleName}'. Please set annotation or specify a correlation id resolver for type '$sagaTypename'")
+            }
+          }).getName
+        case Some(a) => a.fieldname()
+      }
+
+      Some(Try {
+        eventClass.getMethod(fieldname)
+      } match {
+        case Success(method) => method.invoke(event).asInstanceOf[String]
+        case Failure(e) => throw new NoSuchMethodError(s"Saga '$sagaTypename' specifies not existing Correlation id field '$fieldname' for event '${eventClass.getSimpleName}'")
+      })
     }
   }
 }

--- a/src/main/scala/juju/domain/resolvers/ByConventions.scala
+++ b/src/main/scala/juju/domain/resolvers/ByConventions.scala
@@ -64,6 +64,18 @@ object ByConventions {
     override def wakeUpBy(): Seq[Class[_ <: WakeUp]] = handleMethods[S]("wakeup")
       .map(_.getParameterTypes.head.asInstanceOf[Class[_ <: WakeUp]])
       .filter(_ != classOf[WakeUp])
-    override def activateBy() : Option[Class[_ <: Activate]] = None
+    override def activateBy() : Option[Class[_ <: Activate]] = {
+      val sagaClass = implicitly[ClassTag[S]].runtimeClass
+      val activate = sagaClass.getDeclaredAnnotations find { _.annotationType() == classOf[ActivatedBy] }
+
+      val t = activate.map (_.asInstanceOf[ActivatedBy].message)
+
+      val res = if (t.isDefined && classOf[Activate].isAssignableFrom(t.get)) {
+        Some(t.get).asInstanceOf[Option[Class[_ <: Activate]]]
+      } else {
+        None.asInstanceOf[Option[Class[_ <: Activate]]]
+      }
+      res
+    }
   }
 }

--- a/src/test/scala/juju/domain/AggregateRootSpec.scala
+++ b/src/test/scala/juju/domain/AggregateRootSpec.scala
@@ -3,7 +3,7 @@ package juju.domain
 import akka.actor._
 import juju.sample.{PersonAggregate, PriorityAggregate}
 import juju.sample.PriorityAggregate.{PriorityIncreased, IncreasePriority, PriorityCreated, CreatePriority}
-import PersonAggregate.{WeightChanged, ChangeWeight}
+import juju.sample.PersonAggregate._
 import juju.testkit.LocalDomainSpec
 
 class AggregateRootSpec extends LocalDomainSpec("AggregateRoot") {
@@ -24,9 +24,26 @@ class AggregateRootSpec extends LocalDomainSpec("AggregateRoot") {
     expectMsg(PriorityIncreased("giangi", 2))
   }
 
-  it should "be able to handle commands implementing Handle trait" in {
+  it should "be able to handle command by convention" in {
     val fakeRef = system.actorOf(Props(classOf[PersonAggregate]))
+
+    fakeRef ! CreatePerson("giangi")
+    expectMsg(PersonCreated("giangi"))
+
     fakeRef ! ChangeWeight("giangi", 80)
     expectMsg(WeightChanged("giangi", 80))
+  }
+
+  it should "be able to handle more commands by convention" in {
+    val fakeRef = system.actorOf(Props(classOf[PersonAggregate]))
+
+    fakeRef ! CreatePerson("giangi")
+    expectMsg(PersonCreated("giangi"))
+
+    fakeRef ! ChangeWeight("giangi", 80)
+    expectMsg(WeightChanged("giangi", 80))
+
+    fakeRef ! ChangeHeight("giangi", 180)
+    expectMsg(HeightChanged("giangi", 180))
   }
 }

--- a/src/test/scala/juju/domain/AggregateRootSpec.scala
+++ b/src/test/scala/juju/domain/AggregateRootSpec.scala
@@ -3,6 +3,8 @@ package juju.domain
 import akka.actor._
 import juju.sample.PriorityAggregate
 import juju.sample.PriorityAggregate.{PriorityIncreased, IncreasePriority, PriorityCreated, CreatePriority}
+import juju.sample.conventions.PersonAggregate
+import juju.sample.conventions.PersonAggregate.{WeightChanged, ChangeWeight}
 import juju.testkit.LocalDomainSpec
 
 class AggregateRootSpec extends LocalDomainSpec("AggregateRoot") {
@@ -21,5 +23,11 @@ class AggregateRootSpec extends LocalDomainSpec("AggregateRoot") {
     expectMsg(PriorityIncreased("giangi", 1))
     fakeRef ! IncreasePriority("giangi")
     expectMsg(PriorityIncreased("giangi", 2))
+  }
+
+  it should "be able to handle commands implementing Handle trait" in {
+    val fakeRef = system.actorOf(Props(classOf[PersonAggregate]))
+    fakeRef ! ChangeWeight("giangi", 80)
+    expectMsg(WeightChanged("giangi", 80))
   }
 }

--- a/src/test/scala/juju/domain/AggregateRootSpec.scala
+++ b/src/test/scala/juju/domain/AggregateRootSpec.scala
@@ -1,10 +1,9 @@
 package juju.domain
 
 import akka.actor._
-import juju.sample.PriorityAggregate
+import juju.sample.{PersonAggregate, PriorityAggregate}
 import juju.sample.PriorityAggregate.{PriorityIncreased, IncreasePriority, PriorityCreated, CreatePriority}
-import juju.sample.conventions.PersonAggregate
-import juju.sample.conventions.PersonAggregate.{WeightChanged, ChangeWeight}
+import PersonAggregate.{WeightChanged, ChangeWeight}
 import juju.testkit.LocalDomainSpec
 
 class AggregateRootSpec extends LocalDomainSpec("AggregateRoot") {

--- a/src/test/scala/juju/domain/SagaSpec.scala
+++ b/src/test/scala/juju/domain/SagaSpec.scala
@@ -2,9 +2,11 @@ package juju.domain
 
 import akka.actor._
 import akka.pattern.gracefulStop
+import juju.sample.AveragePersonWeightSaga.{PublishAverageWeight, PublishWakeUp}
 import juju.sample.ColorAggregate.ChangeWeight
 import juju.sample.ColorPriorityAggregate.ColorAssigned
-import juju.sample.PriorityActivitiesSaga
+import juju.sample.PersonAggregate.WeightChanged
+import juju.sample.{AveragePersonWeightSaga, PriorityActivitiesSaga}
 import juju.sample.PriorityAggregate.PriorityIncreased
 import juju.testkit.LocalDomainSpec
 
@@ -43,5 +45,18 @@ class SagaSpec extends LocalDomainSpec("Saga") {
 
     system.actorOf(Props(classOf[PriorityActivitiesSaga], 3, this.testActor), s"fakesaga-4")
     expectNoMsg()
+  }
+
+  it should "be able to handle events by apply method" in {
+    val sagaRef = system.actorOf(Props(classOf[AveragePersonWeightSaga], this.testActor), s"fakesaga-5")
+    sagaRef ! WeightChanged("x", 80)
+    expectNoMsg(1 second)
+  }
+
+  it should "be able to wakeup by wakeup method" in {
+    val sagaRef = system.actorOf(Props(classOf[AveragePersonWeightSaga], this.testActor), s"fakesaga-6")
+    sagaRef ! WeightChanged("x", 80)
+    sagaRef ! PublishWakeUp()
+    expectMsg(3000 seconds, PublishAverageWeight(80))
   }
 }

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -2,7 +2,7 @@ package juju.domain.resolvers
 
 import juju.domain.AggregateRoot.{AggregateHandlersResolution, AggregateIdResolution}
 import juju.domain._
-import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
+import juju.sample.PersonAggregate._
 import juju.sample.PriorityAggregate.{CreatePriority, PriorityCreated}
 import juju.sample.{ColorAggregate, PersonAggregate, PriorityAggregate}
 import juju.testkit.LocalDomainSpec
@@ -11,10 +11,9 @@ import scala.reflect.ClassTag
 
 class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
 
-  it should "retrieve aggregate supported commands" in {
+  it should "retrieves commands supported by the aggregate" in {
     val supportedCommands = ByConventions.handlersResolution[PersonAggregate]().resolve()
-    supportedCommands should have length 1
-    supportedCommands.head shouldBe classOf[ChangeWeight]
+    supportedCommands should contain allOf (classOf[CreatePerson], classOf[ChangeWeight], classOf[ChangeHeight])
   }
 
   it should "returns empty if aggregate doesn't provide handle specific methods" in {
@@ -22,9 +21,13 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     supportedCommands should be ('empty)
   }
 
-  it should "create Aggregate using byConvention factory" in {
+  it should "creates Aggregate using byConvention factory" in {
     val props = ByConventions.factory[PersonAggregate]().props
     val fakeRef = system.actorOf(props)
+
+    fakeRef ! CreatePerson("giangi")
+    expectMsg(timeout.duration, PersonCreated("giangi"))
+
     fakeRef ! ChangeWeight("giangi", 80)
     expectMsg(WeightChanged("giangi", 80))
   }
@@ -35,24 +38,19 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
-    /*the [IllegalArgumentException] thrownBy {
-      ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))
-    } should have message "Not provided AggregateIdField annotation for command 'CommandWithNoAnnotation'. Please set annotation or specify an id resolver for type 'PersonAggregate'"
-  */
     the [IllegalArgumentException] thrownBy {
       ByConventions.idResolution[AggregateWithNoAnnotation]().resolve(ChangeWeight("giangi", 1))
     } should have message "Not provided AggregateIdField annotation for command 'ChangeWeight'. Please set annotation or specify an id resolver for type 'AggregateWithNoAnnotation'"
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
-    /*the [NoSuchMethodError] thrownBy {
-      ByConventions.idResolution[PersonAggregate]().resolve(CommandWithInvalidAnnotation("giangi"))
-    } should have message "Command 'CommandWithInvalidAnnotation' have no Aggregate id field 'notexistingfield'"
-    */
     the [NoSuchMethodError] thrownBy {
       ByConventions.idResolution[AggregateWithInvalidAnnotation]().resolve(ChangeWeight("giangi", 1))
     } should have message "Aggregate 'AggregateWithInvalidAnnotation' specifies not existing Aggregate id field 'notexistingfield' for command 'ChangeWeight'"
   }
+
+  //TODO: add tests for aggregateid field convention name 'AggregateName + Id'
+  //TODO: add tests for aggregateid field convention name 'Id'
 
   it should "be able to use convention from office" in {
     import juju.infrastructure.local.LocalOffice
@@ -61,11 +59,15 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     implicit def factory[A <: AggregateRoot[_] : ClassTag] : AggregateRootFactory[A] = ByConventions.factory[A]()
     implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag] : AggregateHandlersResolution[A] = ByConventions.handlersResolution[A]()
 
+    system.eventStream.subscribe(this.testActor, classOf[PersonCreated])
     system.eventStream.subscribe(this.testActor, classOf[WeightChanged])
 
     val officeRef = LocalOffice.localOfficeFactory[PersonAggregate](tenant).getOrCreate
-    officeRef ! ChangeWeight("giangi", 80)
 
+    officeRef ! CreatePerson("giangi")
+    expectMsg(timeout.duration, PersonCreated("giangi"))
+
+    officeRef ! ChangeWeight("giangi", 80)
     expectMsg(timeout.duration, WeightChanged("giangi", 80))
   }
 
@@ -87,26 +89,33 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     expectMsg(timeout.duration, PriorityCreated("giangi"))
   }
 
-  //case class CommandWithNoAnnotation(dummy: String) extends Command
-  //@AggregateIdField(fieldname = "notexistingfield") case class CommandWithInvalidAnnotation(dummy: String) extends Command
+  /* it should "retrieves events supported by the saga" in {
+    /*
+    val supportedCommands = ByConventions.handlersResolution[PersonAggregate]().resolve()
+    supportedCommands should have length 1
+    supportedCommands.head shouldBe classOf[ChangeWeight]
+    */
+    assert(false, "not yet implemented")
+  }*/
 
-  class AggregateWithInvalidAnnotation extends AggregateRoot[EmptyState] with Handle[ChangeWeight] {
+
+  class AggregateWithInvalidAnnotation extends AggregateRoot[EmptyState] {
     override val factory: AggregateStateFactory = {
       case _ => throw new IllegalArgumentException("Cannot create the aggregate")
     }
 
     @AggregateIdField(fieldname = "notexistingfield")
-    override def handle(command: ChangeWeight): Unit = command match {
+    def handle(command: ChangeWeight): Unit = command match {
       case _ =>
     }
   }
 
-  class AggregateWithNoAnnotation extends AggregateRoot[EmptyState] with Handle[ChangeWeight] {
+  class AggregateWithNoAnnotation extends AggregateRoot[EmptyState] {
     override val factory: AggregateStateFactory = {
       case _ => throw new IllegalArgumentException("Cannot create the aggregate")
     }
 
-    override def handle(command: ChangeWeight): Unit = command match {
+    def handle(command: ChangeWeight): Unit = command match {
       case _ =>
     }
   }

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -2,8 +2,9 @@ package juju.domain.resolvers
 
 import juju.domain.AggregateRoot.{AggregateHandlersResolution, AggregateIdResolution}
 import juju.domain._
+import juju.domain.resolvers.ByConventionsSpec._
 import juju.messages.Activate
-import juju.sample.AveragePersonWeightSaga.{PublishWakeUp, PublishRequested}
+import juju.sample.AveragePersonWeightSaga.{PublishAverageWeight, PublishWakeUp, PublishRequested}
 import juju.sample.PersonAggregate._
 import juju.sample.PriorityAggregate.{CreatePriority, PriorityCreated}
 import juju.sample._
@@ -15,16 +16,16 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
 
   it should "retrieves commands supported by the aggregate" in {
     val supportedCommands = ByConventions.aggregateHandlersResolution[PersonAggregate]().resolve()
-    supportedCommands should contain allOf (classOf[CreatePerson], classOf[ChangeWeight], classOf[ChangeHeight])
+    supportedCommands should contain allOf(classOf[CreatePerson], classOf[ChangeWeight], classOf[ChangeHeight])
   }
 
   it should "returns empty if aggregate doesn't provide handle specific methods" in {
     val supportedCommands = ByConventions.aggregateHandlersResolution[ColorAggregate]().resolve()
-    supportedCommands should be ('empty)
+    supportedCommands should be('empty)
   }
 
   it should "creates Aggregate using byConvention factory" in {
-    val props = ByConventions.factory[PersonAggregate]().props
+    val props = ByConventions.aggregateFactory[PersonAggregate]().props
     val fakeRef = system.actorOf(props)
 
     fakeRef ! CreatePerson("giangi")
@@ -35,20 +36,20 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
   }
 
   it should "extract aggregate id from command using byConvention resolver" in {
-    val aggregateId = ByConventions.idResolution[PersonAggregate]().resolve(ChangeWeight("giangi", 80))
+    val aggregateId = ByConventions.aggregateIdResolution[AggregateWithValidHandleAnnotation]().resolve(ChangeWeight("giangi", 80))
     aggregateId shouldBe "giangi"
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
-    the [IllegalArgumentException] thrownBy {
-      ByConventions.idResolution[AggregateWithNoAnnotation]().resolve(ChangeWeight("giangi", 1))
-    } should have message "Not provided AggregateIdField annotation for command 'ChangeWeight'. Please set annotation or specify an id resolver for type 'AggregateWithNoAnnotation'"
+    the[IllegalArgumentException] thrownBy {
+      ByConventions.aggregateIdResolution[AggregateWithNoHandleAnnotation]().resolve(ChangeWeight("giangi", 1))
+    } should have message "Not provided AggregateIdField annotation for command 'ChangeWeight'. Please set annotation or specify an id resolver for type 'AggregateWithNoHandleAnnotation'"
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
-    the [NoSuchMethodError] thrownBy {
-      ByConventions.idResolution[AggregateWithInvalidAnnotation]().resolve(ChangeWeight("giangi", 1))
-    } should have message "Aggregate 'AggregateWithInvalidAnnotation' specifies not existing Aggregate id field 'notexistingfield' for command 'ChangeWeight'"
+    the[NoSuchMethodError] thrownBy {
+      ByConventions.aggregateIdResolution[AggregateWithInvalidHandleAnnotation]().resolve(ChangeWeight("giangi", 1))
+    } should have message "Aggregate 'AggregateWithInvalidHandleAnnotation' specifies not existing Aggregate id field 'notexistingfield' for command 'ChangeWeight'"
   }
 
   //TODO: add tests for aggregateid field convention name 'AggregateName + Id'
@@ -57,9 +58,9 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
   it should "be able to use convention from office" in {
     import juju.infrastructure.local.LocalOffice
 
-    implicit def idResolution[A <: AggregateRoot[_] : ClassTag] : AggregateIdResolution[A] = ByConventions.idResolution[A]()
-    implicit def factory[A <: AggregateRoot[_] : ClassTag] : AggregateRootFactory[A] = ByConventions.factory[A]()
-    implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag] : AggregateHandlersResolution[A] = ByConventions.aggregateHandlersResolution[A]()
+    implicit def idResolution[A <: AggregateRoot[_] : ClassTag]: AggregateIdResolution[A] = ByConventions.aggregateIdResolution[A]()
+    implicit def factory[A <: AggregateRoot[_] : ClassTag]: AggregateRootFactory[A] = ByConventions.aggregateFactory[A]()
+    implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag]: AggregateHandlersResolution[A] = ByConventions.aggregateHandlersResolution[A]()
 
     system.eventStream.subscribe(this.testActor, classOf[PersonCreated])
     system.eventStream.subscribe(this.testActor, classOf[WeightChanged])
@@ -76,9 +77,9 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
   it should "be able to override convention from office with more specific type" in {
     import juju.infrastructure.local.LocalOffice
 
-    implicit def idResolution[A <: AggregateRoot[_] : ClassTag] : AggregateIdResolution[A] = ByConventions.idResolution[A]()
-    implicit def factory[A <: AggregateRoot[_] : ClassTag] : AggregateRootFactory[A] = ByConventions.factory[A]()
-    implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag] : AggregateHandlersResolution[A] = ByConventions.aggregateHandlersResolution[A]()
+    implicit def idResolution[A <: AggregateRoot[_] : ClassTag]: AggregateIdResolution[A] = ByConventions.aggregateIdResolution[A]()
+    implicit def factory[A <: AggregateRoot[_] : ClassTag]: AggregateRootFactory[A] = ByConventions.aggregateFactory[A]()
+    implicit def handlersResolution[A <: AggregateRoot[_] : ClassTag]: AggregateHandlersResolution[A] = ByConventions.aggregateHandlersResolution[A]()
 
     implicit val priorityAggregateIdResolution = PriorityAggregate.idResolution
     implicit val priorityAggregateHandlersResolution = PriorityAggregate.handlersResolution
@@ -91,40 +92,83 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     expectMsg(timeout.duration, PriorityCreated("giangi"))
   }
 
-   it should "retrieves events supported by the saga" in {
-     val supportedEvents = ByConventions.sagaHandlersResolution[AveragePersonWeightSaga]().resolve()
-     supportedEvents should contain allOf (classOf[WeightChanged], classOf[PublishRequested])
+  it should "retrieves events supported by the saga" in {
+    val supportedEvents = ByConventions.sagaHandlersResolution[AveragePersonWeightSaga]().resolve()
+    supportedEvents should contain allOf(classOf[WeightChanged], classOf[PublishRequested])
   }
 
   it should "returns empty if saga doesn't provide apply specific methods" in {
     val supportedEvents = ByConventions.sagaHandlersResolution[PriorityActivitiesSaga]().resolve()
-    supportedEvents should be ('empty)
+    supportedEvents should be('empty)
   }
 
   it should "retrieves wakeup supported by the saga" in {
     val supportedWakeups = ByConventions.sagaHandlersResolution[AveragePersonWeightSaga]().wakeUpBy()
-    supportedWakeups should contain (classOf[PublishWakeUp])
+    supportedWakeups should contain(classOf[PublishWakeUp])
   }
 
   it should "returns empty if saga doesn't provide wakeup specific methods" in {
     val supportedWakeups = ByConventions.sagaHandlersResolution[PriorityActivitiesSaga]().wakeUpBy()
-    supportedWakeups should be ('empty)
+    supportedWakeups should be('empty)
   }
 
   it should "retrieves activate supported by the saga" in {
     val supportedActivate = ByConventions.sagaHandlersResolution[SagaWithActivation]().activateBy()
     supportedActivate should not be None
     val clazz = supportedActivate.get.getName
-    clazz should be (classOf[SagaActivate].getName)
+    clazz should be(classOf[SagaActivate].getName)
   }
 
   it should "returns None if saga doesn't provide activate annotation" in {
-    val supportedActivates = ByConventions.sagaHandlersResolution[SagaWithNoActivation]().activateBy()
-    supportedActivates should be (None)
+    val supportedActivates = ByConventions.sagaHandlersResolution[SagaWithNoActivationAnnotation]().activateBy()
+    supportedActivates should be(None)
   }
 
+  it should "creates Saga using byConvention factory" in {
+    val props = ByConventions.sagaFactory[AveragePersonWeightSaga]().props("fake", this.testActor)
+    val fakeRef = system.actorOf(props)
 
-  class AggregateWithInvalidAnnotation extends AggregateRoot[EmptyState] {
+    fakeRef ! WeightChanged("giangi", 80)
+
+    fakeRef ! PublishWakeUp()
+    expectMsg(PublishAverageWeight(80))
+  }
+
+  it should "extract correlation id from command using byConvention resolver" in {
+    val correlationId = ByConventions.correlationIdResolution[SagaWithValidApplyAnnotation]().resolve(WeightChanged("giangi", 80))
+    correlationId should not be None
+    correlationId.get shouldBe "giangi"
+  }
+
+  it should "throw error if correlation id from command byConvention resolver doesn't find CorrelationIdField annotation" in {
+    the[IllegalArgumentException] thrownBy {
+      ByConventions.correlationIdResolution[SagaWithNoApplyAnnotation]().resolve(WeightChanged("giangi", 80))
+    } should have message "Not provided CorrelationIdField annotation for event 'WeightChanged'. Please set annotation or specify a correlation id resolver for type 'SagaWithNoApplyAnnotation'"
+  }
+
+  it should "throw error if correlation id from command byConvention resolver doesn't exist" in {
+    the[NoSuchMethodError] thrownBy {
+      ByConventions.correlationIdResolution[SagaWithInvalidApplyAnnotation]().resolve(WeightChanged("giangi", 80))
+    } should have message "Saga 'SagaWithInvalidApplyAnnotation' specifies not existing Correlation id field 'notexistingfield' for event 'WeightChanged'"
+  }
+
+  //TODO: add tests for correlationId field convention name 'Correlation + Id'
+  //TODO: add tests for correlationId field convention name 'Id'
+
+}
+object ByConventionsSpec {
+  class AggregateWithValidHandleAnnotation extends AggregateRoot[EmptyState] {
+    override val factory: AggregateStateFactory = {
+      case _ => throw new IllegalArgumentException("Cannot create the aggregate")
+    }
+
+    @AggregateIdField(fieldname = "name")
+    def handle(command: ChangeWeight): Unit = command match {
+      case _ =>
+    }
+  }
+
+  class AggregateWithInvalidHandleAnnotation extends AggregateRoot[EmptyState] {
     override val factory: AggregateStateFactory = {
       case _ => throw new IllegalArgumentException("Cannot create the aggregate")
     }
@@ -135,7 +179,7 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     }
   }
 
-  class AggregateWithNoAnnotation extends AggregateRoot[EmptyState] {
+  class AggregateWithNoHandleAnnotation extends AggregateRoot[EmptyState] {
     override val factory: AggregateStateFactory = {
       case _ => throw new IllegalArgumentException("Cannot create the aggregate")
     }
@@ -147,5 +191,15 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
 
   case class SagaActivate(override val correlationId: String) extends Activate
   @ActivatedBy(message = classOf[SagaActivate]) class SagaWithActivation extends Saga {}
-  class SagaWithNoActivation extends Saga {}
+  class SagaWithNoActivationAnnotation extends Saga {}
+
+  class SagaWithValidApplyAnnotation extends Saga {
+    @CorrelationIdField(fieldname = "name")def apply(event: WeightChanged): Unit = ???
+  }
+  class SagaWithInvalidApplyAnnotation extends Saga {
+    @CorrelationIdField(fieldname = "notexistingfield")def apply(event: WeightChanged): Unit = ???
+  }
+  class SagaWithNoApplyAnnotation extends Saga {
+    def apply(event: WeightChanged): Unit = ???
+  }
 }

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -1,0 +1,19 @@
+package juju.domain.resolvers
+
+import juju.sample.{PersonAggregate, ColorAggregate}
+import juju.sample.PersonAggregate.ChangeWeight
+import juju.testkit.LocalDomainSpec
+
+class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
+
+  it should "retrieve aggregate supported commands" in {
+    val supportedCommands = ByConventions.handlersResolution[PersonAggregate]().resolve()
+    supportedCommands should have length 1
+    supportedCommands.head shouldBe classOf[ChangeWeight]
+  }
+
+  it should "returns empty if aggregate doesn't provide handle specific methods" in {
+    val supportedCommands = ByConventions.handlersResolution[ColorAggregate]().resolve()
+    supportedCommands should be ('empty)
+  }
+}

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -30,23 +30,19 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     aggregateId shouldBe "giangi"
   }
 
-  it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
-    /*an [IllegalArgumentException] shouldBe
-      thrownBy(ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))) should have message ""
-  */
+  it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
     the [IllegalArgumentException] thrownBy {
       ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))
     } should have message "Not provided AggregateIdField annotation for command 'CommandWithNoAnnotation'. Please set annotation or specify an id resolver for type 'PersonAggregate'"
   }
+
+  it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
+    the [NoSuchMethodError] thrownBy {
+      ByConventions.idResolution[PersonAggregate]().resolve(CommandWithInvalidAnnotation("giangi"))
+    } should have message "Command 'CommandWithInvalidAnnotation' have no Aggregate id field 'notexistingfield'"
+  }
+
 /*
-  it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
-    assert(false, "not yet implemented")
-  }
-
-  it should "take first annotation if aggregate id from command byConvention resolver returns more than one AggregateIdField annotations" in {
-    assert(false, "not yet implemented")
-  }
-
 
   it should "be able to use convention from office" in {
     //    import ByConventions._

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -1,10 +1,9 @@
 package juju.domain.resolvers
 
 import juju.domain.AggregateRoot.{AggregateHandlersResolution, AggregateIdResolution}
-import juju.domain.{AggregateRoot, AggregateRootFactory}
-import juju.messages.Command
+import juju.domain._
 import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
-import juju.sample.PriorityAggregate.{PriorityCreated, CreatePriority}
+import juju.sample.PriorityAggregate.{CreatePriority, PriorityCreated}
 import juju.sample.{ColorAggregate, PersonAggregate, PriorityAggregate}
 import juju.testkit.LocalDomainSpec
 
@@ -36,15 +35,23 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
-    the [IllegalArgumentException] thrownBy {
+    /*the [IllegalArgumentException] thrownBy {
       ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))
     } should have message "Not provided AggregateIdField annotation for command 'CommandWithNoAnnotation'. Please set annotation or specify an id resolver for type 'PersonAggregate'"
+  */
+    the [IllegalArgumentException] thrownBy {
+      ByConventions.idResolution[AggregateWithNoAnnotation]().resolve(ChangeWeight("giangi", 1))
+    } should have message "Not provided AggregateIdField annotation for command 'ChangeWeight'. Please set annotation or specify an id resolver for type 'AggregateWithNoAnnotation'"
   }
 
   it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
-    the [NoSuchMethodError] thrownBy {
+    /*the [NoSuchMethodError] thrownBy {
       ByConventions.idResolution[PersonAggregate]().resolve(CommandWithInvalidAnnotation("giangi"))
     } should have message "Command 'CommandWithInvalidAnnotation' have no Aggregate id field 'notexistingfield'"
+    */
+    the [NoSuchMethodError] thrownBy {
+      ByConventions.idResolution[AggregateWithInvalidAnnotation]().resolve(ChangeWeight("giangi", 1))
+    } should have message "Aggregate 'AggregateWithInvalidAnnotation' specifies not existing Aggregate id field 'notexistingfield' for command 'ChangeWeight'"
   }
 
   it should "be able to use convention from office" in {
@@ -80,6 +87,27 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     expectMsg(timeout.duration, PriorityCreated("giangi"))
   }
 
-  case class CommandWithNoAnnotation(dummy: String) extends Command
-  @AggregateIdField(fieldname = "notexistingfield") case class CommandWithInvalidAnnotation(dummy: String) extends Command
+  //case class CommandWithNoAnnotation(dummy: String) extends Command
+  //@AggregateIdField(fieldname = "notexistingfield") case class CommandWithInvalidAnnotation(dummy: String) extends Command
+
+  class AggregateWithInvalidAnnotation extends AggregateRoot[EmptyState] with Handle[ChangeWeight] {
+    override val factory: AggregateStateFactory = {
+      case _ => throw new IllegalArgumentException("Cannot create the aggregate")
+    }
+
+    @AggregateIdField(fieldname = "notexistingfield")
+    override def handle(command: ChangeWeight): Unit = command match {
+      case _ =>
+    }
+  }
+
+  class AggregateWithNoAnnotation extends AggregateRoot[EmptyState] with Handle[ChangeWeight] {
+    override val factory: AggregateStateFactory = {
+      case _ => throw new IllegalArgumentException("Cannot create the aggregate")
+    }
+
+    override def handle(command: ChangeWeight): Unit = command match {
+      case _ =>
+    }
+  }
 }

--- a/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
+++ b/src/test/scala/juju/domain/resolvers/ByConventionsSpec.scala
@@ -1,7 +1,8 @@
 package juju.domain.resolvers
 
-import juju.sample.{PersonAggregate, ColorAggregate}
-import juju.sample.PersonAggregate.ChangeWeight
+import juju.messages.Command
+import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
+import juju.sample.{ColorAggregate, PersonAggregate}
 import juju.testkit.LocalDomainSpec
 
 class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
@@ -16,4 +17,50 @@ class ByConventionsSpec extends LocalDomainSpec("ByConvention") {
     val supportedCommands = ByConventions.handlersResolution[ColorAggregate]().resolve()
     supportedCommands should be ('empty)
   }
+
+  it should "create Aggregate using byConvention factory" in {
+    val props = ByConventions.factory[PersonAggregate]().props
+    val fakeRef = system.actorOf(props)
+    fakeRef ! ChangeWeight("giangi", 80)
+    expectMsg(WeightChanged("giangi", 80))
+  }
+
+  it should "extract aggregate id from command using byConvention resolver" in {
+    val aggregateId = ByConventions.idResolution[PersonAggregate]().resolve(ChangeWeight("giangi", 80))
+    aggregateId shouldBe "giangi"
+  }
+
+  it should "throw error if aggregate id from command byConvention resolver doesn't exist" in {
+    /*an [IllegalArgumentException] shouldBe
+      thrownBy(ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))) should have message ""
+  */
+    the [IllegalArgumentException] thrownBy {
+      ByConventions.idResolution[PersonAggregate]().resolve(CommandWithNoAnnotation("giangi"))
+    } should have message "Not provided AggregateIdField annotation for command 'CommandWithNoAnnotation'. Please set annotation or specify an id resolver for type 'PersonAggregate'"
+  }
+/*
+  it should "throw error if aggregate id from command byConvention resolver doesn't find AggregateIdField annotation" in {
+    assert(false, "not yet implemented")
+  }
+
+  it should "take first annotation if aggregate id from command byConvention resolver returns more than one AggregateIdField annotations" in {
+    assert(false, "not yet implemented")
+  }
+
+
+  it should "be able to use convention from office" in {
+    //    import ByConventions._
+    //val officeRef = LocalOffice.localOfficeFactory[PersonAggregate](tenant).getOrCreate
+    //officeRef ! ChangeWeight("giangi", 80)
+
+    //expectMsg(timeout.duration, WeightChanged("giangi", 80))
+    assert(false, "not yet implemented")
+  }
+
+  it should "be able to override convention from office with more specific type" in {
+    assert(false, "not yet implemented")
+  }*/
+
+  case class CommandWithNoAnnotation(dummy: String) extends Command
+  @AggregateIdField(fieldname = "notexistingfield") case class CommandWithInvalidAnnotation(dummy: String) extends Command
 }

--- a/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
+++ b/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
@@ -12,7 +12,7 @@ object AveragePersonWeightSaga {
   case class PublishRequested() extends DomainEvent
 }
 
-class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
+class AveragePersonWeightSaga(correlationId: String, commandRouter: ActorRef) extends Saga {
   var weights : Map[String, Int] = Map.empty
   var average = 0
   var changed = false

--- a/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
+++ b/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
@@ -1,10 +1,15 @@
 package juju.sample
-//import juju.sample.AveragePersonWeightSaga._
-/*
+
+import akka.actor.ActorRef
+import juju.domain.Saga
+import juju.messages.{DomainEvent, Command, WakeUp, Activate}
+import juju.sample.AveragePersonWeightSaga.{PublishAverageWeight, PublishWakeUp, PublishRequested}
+import juju.sample.PersonAggregate.WeightChanged
+
 object AveragePersonWeightSaga {
   case class ActivateAveragePersonWeight(override val correlationId: String) extends Activate
   case class PublishWakeUp() extends WakeUp
-  case class PublishAverage(weight: Int) extends Command
+  case class PublishAverageWeight(weight: Int) extends Command
   case class PublishRequested() extends DomainEvent
 }
 
@@ -16,83 +21,16 @@ class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
   def apply(event: WeightChanged): Unit = {
     weights = weights.filterNot(_._1 == event.name) + (event.name -> event.weight)
     val newAverage = weights.values.sum / weights.toList.length
-    changed = newAverage == average
+    changed = newAverage != average
     average = newAverage
   }
 
   def apply(event: PublishRequested): Unit = {
+    if (changed) {
+      deliverCommand(commandRouter, PublishAverageWeight(average))
+      changed = false
+    }
   }
 
-  def wakeup(wakeup: PublishWakeUp): Unit = {
-  }
+  def wakeup(wakeup: PublishWakeUp): Unit = raise(PublishRequested())
 }
-*/
-
-/*
-object PriorityActivitiesSaga {
-  case class PriorityActivitiesActivate(correlationId: String) extends Activate
-  case class EchoWakeUp(message: String) extends WakeUp
-  case class EchoReady(message: String) extends DomainEvent
-  case class PublishEcho(message: String) extends Command
-
-  implicit val correlationIdResolution = new SagaCorrelationIdResolution[PriorityActivitiesSaga] {
-    override def resolve(event: DomainEvent): Option[String] = event match {
-      case PriorityIncreased(_, p) if p == -1 => None
-      case PriorityIncreased(_, p) => Some(p.toString)
-      case PriorityDecreased(_, p) if p == -1  => None
-      case PriorityDecreased(_, p) => Some(p.toString)
-      case ColorAssigned(p, c) if p == -1  => None
-      case ColorAssigned(p, c) => Some(p.toString)
-      case _ => ???
-    }
-  }
-
-  implicit val handlersResolution = new SagaHandlersResolution[PriorityActivitiesSaga] {
-    override def resolve() = Seq(classOf[PriorityIncreased], classOf[PriorityDecreased], classOf[ColorAssigned])
-    override def wakeUpBy() = Seq(classOf[EchoWakeUp])
-    override def activateBy() = Some(classOf[PriorityActivitiesActivate])
-  }
-
-  implicit val factory = new SagaFactory[PriorityActivitiesSaga] {
-    override def props(correlationId: String, commandRouter: ActorRef): Props = Props(classOf[PriorityActivitiesSaga], correlationId.toInt, commandRouter)
-  }
-}
-
-class PriorityActivitiesSaga(val priority: Int, commandRouter: ActorRef) extends Saga {
-  var color = ""
-  var activities = 0
-
-  override def applyEvent: PartialFunction[DomainEvent, Unit] = {
-    case PriorityIncreased(_, p) => {
-      activities = activities + 1
-      deliveryChangeWeightIfNeeded(activities)
-    }
-    case PriorityDecreased(_, p) => {
-      activities = activities + 1
-      deliveryChangeWeightIfNeeded(activities)
-    }
-    case ColorAssigned(p, c) => {
-      deliveryChangeWeightIfNeeded(0)
-      color = c
-      deliveryChangeWeightIfNeeded(activities)
-    }
-    case EchoReady(message) =>
-      deliverCommand(commandRouter, PublishEcho(s"echo from priority $priority: $message"))
-  }
-
-  override def receiveEvent: Receive = {
-    case e@PriorityIncreased(_, p) if priority == p || priority == -1 => raise(e)
-    case e@PriorityDecreased(_, p) if priority == p || priority == -1 => raise(e)
-    case e@ColorAssigned(p, c) if priority == p || priority == -1 || c != color => raise(e)
-    case EchoWakeUp(txt) => raise(EchoReady(txt))
-    case _ => ???
-  }
-
-  def deliveryChangeWeightIfNeeded(activities : Int): Unit = {
-    log.debug(s"delivery command to signal $activities")
-    if (color != "") {
-      deliverCommand(commandRouter, ChangeWeight(color, activities))
-    }
-  }
-}
-*/

--- a/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
+++ b/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
@@ -2,19 +2,16 @@ package juju.sample
 
 import akka.actor.ActorRef
 import juju.domain.Saga
-import juju.domain.resolvers.ActivatedBy
-import juju.messages.{Activate, Command, DomainEvent, WakeUp}
-import juju.sample.AveragePersonWeightSaga.{ActivateAveragePersonWeight, PublishAverageWeight, PublishRequested, PublishWakeUp}
+import juju.messages.{Command, DomainEvent, WakeUp}
+import juju.sample.AveragePersonWeightSaga.{PublishAverageWeight, PublishRequested, PublishWakeUp}
 import juju.sample.PersonAggregate.WeightChanged
 
 object AveragePersonWeightSaga {
-  case class ActivateAveragePersonWeight(override val correlationId: String) extends Activate
   case class PublishWakeUp() extends WakeUp
   case class PublishAverageWeight(weight: Int) extends Command
   case class PublishRequested() extends DomainEvent
 }
 
-@ActivatedBy(messages = Array(classOf[ActivateAveragePersonWeight]))
 class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
   var weights : Map[String, Int] = Map.empty
   var average = 0

--- a/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
+++ b/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
@@ -2,8 +2,9 @@ package juju.sample
 
 import akka.actor.ActorRef
 import juju.domain.Saga
-import juju.messages.{DomainEvent, Command, WakeUp, Activate}
-import juju.sample.AveragePersonWeightSaga.{PublishAverageWeight, PublishWakeUp, PublishRequested}
+import juju.domain.resolvers.ActivatedBy
+import juju.messages.{Activate, Command, DomainEvent, WakeUp}
+import juju.sample.AveragePersonWeightSaga.{ActivateAveragePersonWeight, PublishAverageWeight, PublishRequested, PublishWakeUp}
 import juju.sample.PersonAggregate.WeightChanged
 
 object AveragePersonWeightSaga {
@@ -13,6 +14,7 @@ object AveragePersonWeightSaga {
   case class PublishRequested() extends DomainEvent
 }
 
+@ActivatedBy(messages = Array(classOf[ActivateAveragePersonWeight]))
 class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
   var weights : Map[String, Int] = Map.empty
   var average = 0
@@ -25,12 +27,12 @@ class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
     average = newAverage
   }
 
-  def apply(event: PublishRequested): Unit = {
+  def apply(event: PublishRequested): Unit =
     if (changed) {
       deliverCommand(commandRouter, PublishAverageWeight(average))
       changed = false
     }
-  }
+
 
   def wakeup(wakeup: PublishWakeUp): Unit = raise(PublishRequested())
 }

--- a/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
+++ b/src/test/scala/juju/sample/AveragePersonWeightSaga.scala
@@ -1,0 +1,98 @@
+package juju.sample
+//import juju.sample.AveragePersonWeightSaga._
+/*
+object AveragePersonWeightSaga {
+  case class ActivateAveragePersonWeight(override val correlationId: String) extends Activate
+  case class PublishWakeUp() extends WakeUp
+  case class PublishAverage(weight: Int) extends Command
+  case class PublishRequested() extends DomainEvent
+}
+
+class AveragePersonWeightSaga(commandRouter: ActorRef) extends Saga {
+  var weights : Map[String, Int] = Map.empty
+  var average = 0
+  var changed = false
+
+  def apply(event: WeightChanged): Unit = {
+    weights = weights.filterNot(_._1 == event.name) + (event.name -> event.weight)
+    val newAverage = weights.values.sum / weights.toList.length
+    changed = newAverage == average
+    average = newAverage
+  }
+
+  def apply(event: PublishRequested): Unit = {
+  }
+
+  def wakeup(wakeup: PublishWakeUp): Unit = {
+  }
+}
+*/
+
+/*
+object PriorityActivitiesSaga {
+  case class PriorityActivitiesActivate(correlationId: String) extends Activate
+  case class EchoWakeUp(message: String) extends WakeUp
+  case class EchoReady(message: String) extends DomainEvent
+  case class PublishEcho(message: String) extends Command
+
+  implicit val correlationIdResolution = new SagaCorrelationIdResolution[PriorityActivitiesSaga] {
+    override def resolve(event: DomainEvent): Option[String] = event match {
+      case PriorityIncreased(_, p) if p == -1 => None
+      case PriorityIncreased(_, p) => Some(p.toString)
+      case PriorityDecreased(_, p) if p == -1  => None
+      case PriorityDecreased(_, p) => Some(p.toString)
+      case ColorAssigned(p, c) if p == -1  => None
+      case ColorAssigned(p, c) => Some(p.toString)
+      case _ => ???
+    }
+  }
+
+  implicit val handlersResolution = new SagaHandlersResolution[PriorityActivitiesSaga] {
+    override def resolve() = Seq(classOf[PriorityIncreased], classOf[PriorityDecreased], classOf[ColorAssigned])
+    override def wakeUpBy() = Seq(classOf[EchoWakeUp])
+    override def activateBy() = Some(classOf[PriorityActivitiesActivate])
+  }
+
+  implicit val factory = new SagaFactory[PriorityActivitiesSaga] {
+    override def props(correlationId: String, commandRouter: ActorRef): Props = Props(classOf[PriorityActivitiesSaga], correlationId.toInt, commandRouter)
+  }
+}
+
+class PriorityActivitiesSaga(val priority: Int, commandRouter: ActorRef) extends Saga {
+  var color = ""
+  var activities = 0
+
+  override def applyEvent: PartialFunction[DomainEvent, Unit] = {
+    case PriorityIncreased(_, p) => {
+      activities = activities + 1
+      deliveryChangeWeightIfNeeded(activities)
+    }
+    case PriorityDecreased(_, p) => {
+      activities = activities + 1
+      deliveryChangeWeightIfNeeded(activities)
+    }
+    case ColorAssigned(p, c) => {
+      deliveryChangeWeightIfNeeded(0)
+      color = c
+      deliveryChangeWeightIfNeeded(activities)
+    }
+    case EchoReady(message) =>
+      deliverCommand(commandRouter, PublishEcho(s"echo from priority $priority: $message"))
+  }
+
+  override def receiveEvent: Receive = {
+    case e@PriorityIncreased(_, p) if priority == p || priority == -1 => raise(e)
+    case e@PriorityDecreased(_, p) if priority == p || priority == -1 => raise(e)
+    case e@ColorAssigned(p, c) if priority == p || priority == -1 || c != color => raise(e)
+    case EchoWakeUp(txt) => raise(EchoReady(txt))
+    case _ => ???
+  }
+
+  def deliveryChangeWeightIfNeeded(activities : Int): Unit = {
+    log.debug(s"delivery command to signal $activities")
+    if (color != "") {
+      deliverCommand(commandRouter, ChangeWeight(color, activities))
+    }
+  }
+}
+*/

--- a/src/test/scala/juju/sample/PersonAggregate.scala
+++ b/src/test/scala/juju/sample/PersonAggregate.scala
@@ -1,11 +1,12 @@
 package juju.sample
 
+import juju.domain.resolvers.AggregateIdField
 import juju.domain.{AggregateRoot, AggregateState, Handle}
 import juju.messages.{Command, DomainEvent}
 import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
 
 object PersonAggregate {
-  case class ChangeWeight(name: String, weight: Int) extends Command
+  @AggregateIdField(fieldname = "name") case class ChangeWeight(name: String, weight: Int) extends Command
   case class WeightChanged(name: String, weight: Int) extends DomainEvent
 }
 

--- a/src/test/scala/juju/sample/PersonAggregate.scala
+++ b/src/test/scala/juju/sample/PersonAggregate.scala
@@ -1,8 +1,8 @@
-package juju.sample.conventions
+package juju.sample
 
-import juju.domain.{Handle, AggregateState, AggregateRoot}
-import juju.messages.{DomainEvent, Command}
-import juju.sample.conventions.PersonAggregate.{ChangeWeight, WeightChanged}
+import juju.domain.{AggregateRoot, AggregateState, Handle}
+import juju.messages.{Command, DomainEvent}
+import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
 
 object PersonAggregate {
   case class ChangeWeight(name: String, weight: Int) extends Command
@@ -12,7 +12,6 @@ object PersonAggregate {
 case class PersonState(name: String = "", weight: Int = 0) extends AggregateState {
   override def apply = {
     case WeightChanged(c, w) => copy(weight = w)
-    case _ => ???
   }
 }
 
@@ -22,11 +21,7 @@ class PersonAggregate extends AggregateRoot[PersonState] with Handle[ChangeWeigh
     case _ => throw new IllegalArgumentException("Cannot create state from event different that WeightChanged type")
   }
 
-  /*override def handle : Receive = {
-    case ChangeWeight(c,w) => raise(WeightChanged(c,w))
-  }*/
   override def handle(command: ChangeWeight): Unit = command match {
     case ChangeWeight(c,w) => raise(WeightChanged(c,w))
-    case _ => ???
   }
 }

--- a/src/test/scala/juju/sample/PersonAggregate.scala
+++ b/src/test/scala/juju/sample/PersonAggregate.scala
@@ -6,7 +6,7 @@ import juju.messages.{Command, DomainEvent}
 import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
 
 object PersonAggregate {
-  @AggregateIdField(fieldname = "name") case class ChangeWeight(name: String, weight: Int) extends Command
+  case class ChangeWeight(name: String, weight: Int) extends Command
   case class WeightChanged(name: String, weight: Int) extends DomainEvent
 }
 
@@ -22,7 +22,7 @@ class PersonAggregate extends AggregateRoot[PersonState] with Handle[ChangeWeigh
     case _ => throw new IllegalArgumentException("Cannot create state from event different that WeightChanged type")
   }
 
-  override def handle(command: ChangeWeight): Unit = command match {
+  @AggregateIdField(fieldname = "name") override def handle(command: ChangeWeight): Unit = command match {
     case ChangeWeight(c,w) => raise(WeightChanged(c,w))
   }
 }

--- a/src/test/scala/juju/sample/PersonAggregate.scala
+++ b/src/test/scala/juju/sample/PersonAggregate.scala
@@ -1,28 +1,36 @@
 package juju.sample
 
 import juju.domain.resolvers.AggregateIdField
-import juju.domain.{AggregateRoot, AggregateState, Handle}
+import juju.domain.{AggregateRoot, AggregateState}
 import juju.messages.{Command, DomainEvent}
-import juju.sample.PersonAggregate.{ChangeWeight, WeightChanged}
+import juju.sample.PersonAggregate._
 
 object PersonAggregate {
+  case class CreatePerson(name: String) extends Command
+  case class ChangeHeight(name: String, height: Int) extends Command
   case class ChangeWeight(name: String, weight: Int) extends Command
+
+  case class PersonCreated(name: String) extends DomainEvent
   case class WeightChanged(name: String, weight: Int) extends DomainEvent
+  case class HeightChanged(name: String, height: Int) extends DomainEvent
 }
 
-case class PersonState(name: String = "", weight: Int = 0) extends AggregateState {
+case class PersonState(name: String = "", weight: Int = 0, height: Int = 0) extends AggregateState {
   override def apply = {
     case WeightChanged(c, w) => copy(weight = w)
+    case HeightChanged(c, h) => copy(height = h)
   }
 }
 
-class PersonAggregate extends AggregateRoot[PersonState] with Handle[ChangeWeight] {
+class PersonAggregate extends AggregateRoot[PersonState] {
   override val factory: AggregateStateFactory = {
-    case WeightChanged(name, v) => PersonState(name, v)
-    case _ => throw new IllegalArgumentException("Cannot create state from event different that WeightChanged type")
+    case PersonCreated(name) => PersonState(name)
+    case _ => throw new IllegalArgumentException("Cannot create state from event different than CreatePerson type")
   }
 
-  @AggregateIdField(fieldname = "name") override def handle(command: ChangeWeight): Unit = command match {
-    case ChangeWeight(c,w) => raise(WeightChanged(c,w))
-  }
+  @AggregateIdField(fieldname = "name") def handle(command: CreatePerson): Unit = raise(PersonCreated(command.name))
+
+  @AggregateIdField(fieldname = "name") def handle(command: ChangeWeight): Unit = raise(WeightChanged(command.name, command.weight))
+
+  @AggregateIdField(fieldname = "name") def handle(command: ChangeHeight): Unit = raise(HeightChanged(command.name, command.height))
 }

--- a/src/test/scala/juju/sample/conventions/PersonAggregate.scala
+++ b/src/test/scala/juju/sample/conventions/PersonAggregate.scala
@@ -1,0 +1,32 @@
+package juju.sample.conventions
+
+import juju.domain.{Handle, AggregateState, AggregateRoot}
+import juju.messages.{DomainEvent, Command}
+import juju.sample.conventions.PersonAggregate.{ChangeWeight, WeightChanged}
+
+object PersonAggregate {
+  case class ChangeWeight(name: String, weight: Int) extends Command
+  case class WeightChanged(name: String, weight: Int) extends DomainEvent
+}
+
+case class PersonState(name: String = "", weight: Int = 0) extends AggregateState {
+  override def apply = {
+    case WeightChanged(c, w) => copy(weight = w)
+    case _ => ???
+  }
+}
+
+class PersonAggregate extends AggregateRoot[PersonState] with Handle[ChangeWeight] {
+  override val factory: AggregateStateFactory = {
+    case WeightChanged(name, v) => PersonState(name, v)
+    case _ => throw new IllegalArgumentException("Cannot create state from event different that WeightChanged type")
+  }
+
+  /*override def handle : Receive = {
+    case ChangeWeight(c,w) => raise(WeightChanged(c,w))
+  }*/
+  override def handle(command: ChangeWeight): Unit = command match {
+    case ChangeWeight(c,w) => raise(WeightChanged(c,w))
+    case _ => ???
+  }
+}

--- a/src/test/scala/juju/testkit/infrastructure/OfficeSpec.scala
+++ b/src/test/scala/juju/testkit/infrastructure/OfficeSpec.scala
@@ -59,4 +59,4 @@ trait OfficeSpec extends AkkaSpec {
      assert(false, "not yet implemented")
    }
    */
- }
+}


### PR DESCRIPTION
The system provides a bunch of default implementations of services used buy the event bus to:

- discovery supported commands by aggregate
- discovery aggregate id field of supported command by aggregate
- supported events by saga
- correlation id field of supported event by saga
- aggregate and saga factory

take a look at juju.domain.resolvers code package for the implementation and test package for a sample